### PR TITLE
Added logic to CategoryViewSet

### DIFF
--- a/app/product/permissions.py
+++ b/app/product/permissions.py
@@ -1,0 +1,27 @@
+from django.views import View
+from rest_framework import permissions
+from rest_framework.request import Request
+
+from product import choices
+from product.models import Product
+
+
+class IsAdminOrProductOwner(permissions.BasePermission):
+    """
+    TODO: Look in to this
+    """
+
+    def has_object_permission(self, request: Request, view: View, obj: Product) -> bool:
+        if request.user.is_staff:
+            return True
+        return obj.state == choices.REJECTED and obj.created_by == request.user
+
+
+class IsAdminOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission to grant read-only access to all users,
+    but write access to only admin users.
+    """
+
+    def has_permission(self, request: Request, view: View) -> bool:
+        return request.method in permissions.SAFE_METHODS or request.user and request.user.is_staff

--- a/app/product/serializers.py
+++ b/app/product/serializers.py
@@ -1,11 +1,38 @@
+from typing import Union
+
 from rest_framework import serializers
+
 from .models import Category, Product
 
 
 class CategorySerializer(serializers.ModelSerializer):
+    created_by = serializers.SerializerMethodField()
+    last_updated_by = serializers.SerializerMethodField()
+
     class Meta:
         model = Category
-        fields = ['id', 'title', 'slug']
+        fields = "__all__"
+        read_only_fields = ('slug',)
+
+    def create(self, validated_data: dict) -> Category:
+        user = self.context['request'].user
+        category = Category.objects.create(created_by=user, **validated_data)
+        return category
+
+    def update(self, instance: Category, validated_data: dict) -> Category:
+        user = self.context['request'].user
+        instance.last_updated_by = user
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance
+
+    def get_created_by(self, obj: Category) -> Union[str]:
+        return obj.created_by.email if obj.created_by else None
+
+    def get_last_updated_by(self, obj: Category) -> Union[str]:
+        return obj.last_updated_by.email if obj.last_updated_by else None
 
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/app/product/views.py
+++ b/app/product/views.py
@@ -1,14 +1,16 @@
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets
 
 from . import choices
 from .models import Category, Product
+from .permissions import IsAdminOrReadOnly
 from .serializers import CategorySerializer, ProductSerializer
 
 
 class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsAdminOrReadOnly]
+    lookup_field = "uuid"
 
 
 class ProductViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Category Rest API

### Summary

Had a boiler plate Category API and converted it to the fully functional, auth checking REST API. 

### What has been added

- IsAdminOrReadOnly Permission
- CRUD operations for Category
- Improved Category serializer to automatically add created_by or updated_by and made the slug field readonly

### More details

There was no requirement to list the categories however, since I am implementing something I wanted to do it fully.